### PR TITLE
Cutover dockerfile to eclipse-temurin

### DIFF
--- a/covid_symptoms/Dockerfile
+++ b/covid_symptoms/Dockerfile
@@ -16,13 +16,13 @@ RUN svn export https://svn.apache.org/repos/asf/ctakes/trunk@1894987 ctakes
 WORKDIR /tmp
 ## Copy hsql dictionary descriptor into right location
 RUN wget -q -O dict.zip  https://sourceforge.net/projects/ctakesresources/files/snorx_2021aa.zip/download
-RUN mkdir -p /ctakes/resources/org/apache/ctakes/dictionary/lookup/fast/
+RUN mkdir -p /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/
 RUN unzip -o dict.zip -d /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/
 
 COPY CovidPipelineContext.piper /ctakes/ctakes-web-rest/src/main/resources/pipers/Default.piper
 
 # Copy in latest dictionary info
-COPY covid_symptoms_ctakes.bsv /ctakes/resources/org/apache/ctakes/dictionary/lookup/fast/covid.bsv
+COPY covid_symptoms_ctakes.bsv /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/covid.bsv
 COPY covid_symptoms.xml /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/
 COPY pom.xml /ctakes
 

--- a/covid_symptoms/Dockerfile
+++ b/covid_symptoms/Dockerfile
@@ -1,33 +1,30 @@
-FROM openjdk:8-alpine
+FROM eclipse-temurin:8-jdk
 
 # Set to your proxies if necessary to build behind firewalls:
 #ENV HTTP_PROXY="http://10.41.13.6:3128"
 #ENV HTTPS_PROXY="http://10.41.13.6:3128"
 #ENV FTP_PROXY="http://10.41.13.6:3128"
 
-RUN apk update && apk add ca-certificates openssl wget unzip subversion maven
-RUN apk upgrade
+RUN apt-get update && apt-get install -y ca-certificates openssl wget unzip subversion maven
 
-RUN apk add --no-cache nss
-## Download apache-tomcat and extract:
-RUN wget -q https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.21/bin/apache-tomcat-9.0.21.zip
-RUN unzip -q apache-tomcat-9.0.21.zip
+RUN apt-get install -y libnss3
 
 ## Check out version of ctakes with best working web-rest module
 ## Then compile with maven
 RUN svn export https://svn.apache.org/repos/asf/ctakes/trunk@1894987 ctakes
 
-WORKDIR /
-COPY covid_symptoms_ctakes.bsv /ctakes/resources/org/apache/ctakes/dictionary/lookup/fast/covid.bsv
-COPY covid_symptoms.xml /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/
-COPY pom.xml /ctakes
-
+WORKDIR /tmp
 ## Copy hsql dictionary descriptor into right location
 RUN wget -q -O dict.zip  https://sourceforge.net/projects/ctakesresources/files/snorx_2021aa.zip/download
 RUN mkdir -p /ctakes/resources/org/apache/ctakes/dictionary/lookup/fast/
 RUN unzip -o dict.zip -d /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/
 
 COPY CovidPipelineContext.piper /ctakes/ctakes-web-rest/src/main/resources/pipers/Default.piper
+
+# Copy in latest dictionary info
+COPY covid_symptoms_ctakes.bsv /ctakes/resources/org/apache/ctakes/dictionary/lookup/fast/covid.bsv
+COPY covid_symptoms.xml /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/
+COPY pom.xml /ctakes
 
 # recompile, hopefully this part takes less time
 WORKDIR /ctakes
@@ -40,17 +37,7 @@ WORKDIR /ctakes
 RUN mvn compile -pl '!ctakes-distribution' -DskipTests
 RUN mvn install -pl '!ctakes-distribution' -DskipTests
 
-WORKDIR /
-RUN mv /ctakes/ctakes-web-rest/target/ctakes-web-rest.war /apache-tomcat-9.0.21/webapps/
-
-RUN rm -rf /root/.m2
-
-ENV TOMCAT_HOME=/apache-tomcat-9.0.21
+FROM tomcat:9.0.70-jre8-temurin
+COPY --from=0 /ctakes/ctakes-web-rest/target/ctakes-web-rest.war $CATALINA_HOME/webapps/
 ENV CTAKES_HOME=/ctakes
-
-EXPOSE 8080
-
-WORKDIR $TOMCAT_HOME
-RUN chmod u+x bin/*.sh
-
-CMD bin/catalina.sh run
+CMD ["catalina.sh", "run"]


### PR DESCRIPTION
This commit makes the following major changes:
- Due to a combination of M1-specific issues and the deprecation of the openjdk image, this commit changes the root image used to build the ctakes docker container.
- The dockerfile has been split this out into a multistage build, so that none of the JDK infrastructure is included in the final image, only the compiled WAR is. This has cut the final image size down quite a bit (pending verification that it's actually working correctly).

It also makes the final minor changes:
- The apt-get upgrade step was removed, since this can occasionally cause unexpected dependency issues.
- The order of the hsql dependency and the in repo bsv copies have been switched to leverage some of docker's build step caching for compilation speed on subsequent builds
- Moved the hsql.zip expansion to a temp directory rather than the image root, juuust in case for security reasons.