### PR TITLE
Dockefile quality cleanup

### DIFF
--- a/covid_symptoms/Dockerfile
+++ b/covid_symptoms/Dockerfile
@@ -1,13 +1,11 @@
-FROM eclipse-temurin:8-jdk
+FROM eclipse-temurin:8-jdk as java_build
 
 # Set to your proxies if necessary to build behind firewalls:
 #ENV HTTP_PROXY="http://10.41.13.6:3128"
 #ENV HTTPS_PROXY="http://10.41.13.6:3128"
 #ENV FTP_PROXY="http://10.41.13.6:3128"
 
-RUN apt-get update && apt-get install -y ca-certificates openssl wget unzip subversion maven
-
-RUN apt-get install -y libnss3
+RUN apt-get update && apt-get install -y ca-certificates openssl wget unzip subversion maven libnss3
 
 ## Check out version of ctakes with best working web-rest module
 ## Then compile with maven
@@ -16,7 +14,6 @@ RUN svn export https://svn.apache.org/repos/asf/ctakes/trunk@1894987 ctakes
 WORKDIR /tmp
 ## Copy hsql dictionary descriptor into right location
 RUN wget -q -O dict.zip  https://sourceforge.net/projects/ctakesresources/files/snorx_2021aa.zip/download
-RUN mkdir -p /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/
 RUN unzip -o dict.zip -d /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/
 
 COPY CovidPipelineContext.piper /ctakes/ctakes-web-rest/src/main/resources/pipers/Default.piper
@@ -37,7 +34,7 @@ WORKDIR /ctakes
 RUN mvn compile -pl '!ctakes-distribution' -DskipTests
 RUN mvn install -pl '!ctakes-distribution' -DskipTests
 
-FROM tomcat:9.0.70-jre8-temurin
-COPY --from=0 /ctakes/ctakes-web-rest/target/ctakes-web-rest.war $CATALINA_HOME/webapps/
+FROM tomcat:9.0-jre8-temurin
+COPY --from=java_build /ctakes/ctakes-web-rest/target/ctakes-web-rest.war $CATALINA_HOME/webapps/
 ENV CTAKES_HOME=/ctakes
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
This commit addresses the minor issues raised on pull request #3:
- removes redundant steps
- refers to build stage by named alias
- pins tomcat to minor version instead of patch version