### PR TITLE
feat: allow overriding symptoms.bsv from outside the container

### DIFF
--- a/covid_symptoms/CovidPipelineContext.piper
+++ b/covid_symptoms/CovidPipelineContext.piper
@@ -15,6 +15,6 @@ addDescription concurrent.ThreadSafePosTagger
 // Add Chunkers
 load TsChunkerSubPipe
 
-add DefaultJCasTermAnnotator LookupXml=/org/apache/ctakes/dictionary/lookup/fast/covid_symptoms.xml
+add DefaultJCasTermAnnotator LookupXml=/org/apache/ctakes/dictionary/lookup/fast/symptoms.xml
 
 add ContextAnnotator

--- a/covid_symptoms/Dockerfile
+++ b/covid_symptoms/Dockerfile
@@ -19,8 +19,8 @@ RUN unzip -o dict.zip -d /ctakes/ctakes-web-rest/src/main/resources/org/apache/c
 COPY CovidPipelineContext.piper /ctakes/ctakes-web-rest/src/main/resources/pipers/Default.piper
 
 # Copy in latest dictionary info
-COPY covid_symptoms_ctakes.bsv /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/covid.bsv
-COPY covid_symptoms.xml /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/
+COPY covid_symptoms_ctakes.bsv /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/symptoms.bsv
+COPY covid_symptoms.xml /ctakes/ctakes-web-rest/src/main/resources/org/apache/ctakes/dictionary/lookup/fast/symptoms.xml
 COPY pom.xml /ctakes
 
 # recompile, hopefully this part takes less time
@@ -36,5 +36,12 @@ RUN mvn install -pl '!ctakes-distribution' -DskipTests
 
 FROM tomcat:9.0-jre8-temurin
 COPY --from=java_build /ctakes/ctakes-web-rest/target/ctakes-web-rest.war $CATALINA_HOME/webapps/
+
+# Install a custom <Context> and some tooling to support overriding symptoms.bsv on the fly
+COPY tomcat-context.xml $CATALINA_HOME/conf/context.xml
+COPY restart-on-change /bin
+RUN mkdir /overrides
+RUN apt-get update && apt-get install -y inotify-tools
+
 ENV CTAKES_HOME=/ctakes
-CMD ["catalina.sh", "run"]
+CMD ["restart-on-change", "/overrides", "catalina.sh", "run"]

--- a/covid_symptoms/covid_symptoms.xml
+++ b/covid_symptoms/covid_symptoms.xml
@@ -26,7 +26,7 @@
          <name>CustomCuiRareWord</name>
          <implementationName>org.apache.ctakes.dictionary.lookup2.dictionary.BsvRareWordDictionary</implementationName>
          <properties>
-            <property key="bsvPath" value="org/apache/ctakes/dictionary/lookup/fast/covid.bsv"/>
+            <property key="bsvPath" value="org/apache/ctakes/dictionary/lookup/fast/symptoms.bsv"/>
          </properties>
       </dictionary>
       <dictionary>
@@ -53,7 +53,7 @@
          <name>CustomCuiConcept</name>
          <implementationName>org.apache.ctakes.dictionary.lookup2.concept.BsvConceptFactory</implementationName>
          <properties>
-            <property key="bsvPath" value="org/apache/ctakes/dictionary/lookup/fast/covid.bsv"/>
+            <property key="bsvPath" value="org/apache/ctakes/dictionary/lookup/fast/symptoms.bsv"/>
          </properties>
       </conceptFactory>
       <conceptFactory>

--- a/covid_symptoms/restart-on-change
+++ b/covid_symptoms/restart-on-change
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Originally based off Gary van der Merwe's code on StackOverflow:
+# https://stackoverflow.com/questions/12264238/restart-process-on-file-change-in-linux
+# License is CC-BY-SA 3.0
+#
+# Modifications:
+# 1. Argument handling (vs just watching pwd)
+# 2. Fixed sigint_handler to use INT not SIGINT
+# 3. Use -q
+# 4. Use -KILL
+
+TARGET="$1"
+shift
+
+sigint_handler()
+{
+  kill -KILL $PID
+  exit
+}
+
+trap sigint_handler INT
+
+while true; do
+  $@ &
+  PID=$!
+  inotifywait -q -e modify -e move -e create -e delete -e attrib -r "$TARGET"
+  # We use -KILL (rather than default -TERM) to ensure there is no race condition between when
+  # tomcat severs existing connections and a window where it might accept new ones.
+  # If a connected client sees us disconnect from dying, and then we accept new connections, it
+  # will know the new connection is from the restarted instance.
+  kill -KILL $PID
+done

--- a/covid_symptoms/tomcat-context.xml
+++ b/covid_symptoms/tomcat-context.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Context>
+    <!--
+     Allow overriding the default shipped config for cTAKES.
+
+     The intended flow is to directly mount a file as "/overrides/symptoms.bsv",
+     or instead mount a whole directory as "/overrides".
+     A docker mount like: type=bind,src=./custom.bsv,dst=/overrides/symptoms.bsv,ro
+
+     More allowed overrides might happen in the future, but this is what we support today.
+
+     I tried adding a WatchedResource for this file, to avoid having to restart the container.
+     But something about cTAKES really did not like that, and it kept crashing upon restart.
+     Instead, we use a script (restart-on-change) to watch the file for us.
+
+     See https://tomcat.apache.org/tomcat-9.0-doc/config/resources.html for how the config works.
+    -->
+    <Resources>
+        <PreResources base="/overrides"
+                      className="org.apache.catalina.webresources.DirResourceSet"
+                      readOnly="true"
+                      webAppMount="/WEB-INF/classes/org/apache/ctakes/dictionary/lookup/fast" />
+    </Resources>
+
+    <!-- Below this line is the original, default tomcat9 context.xml settings -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+    <WatchedResource>WEB-INF/tomcat-web.xml</WatchedResource>
+    <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
+</Context>


### PR DESCRIPTION
This adds new support for customizing the dictionary at run time.

You mount a new bsv file into the container at /overrides/symptoms.bsv like so: type=bind,src=./custom.bsv,dst=/overrides/symptoms.bsv,ro

And upon startup, cTAKES will use that dictionary instead of its default Covid one.

Any changes to the file will be noticed and cTAKES will be restarted. Though note that for this to work correctly, you should bind mount the directory of the file, not the file itself.

This is mostly for prototyping a new computable phenotype for now,
 but we might extend this further in the future.

The two files that might be interesting to override are:
- symptoms.bsv
- symptoms.xml (which sets up some dictionary parameters)
