### PR TITLE
fix: wait for cTAKES port to be free after restarting

### DIFF
--- a/covid_symptoms/restart-on-change
+++ b/covid_symptoms/restart-on-change
@@ -30,4 +30,8 @@ while true; do
   # If a connected client sees us disconnect from dying, and then we accept new connections, it
   # will know the new connection is from the restarted instance.
   kill -KILL $PID
+  # Wait for port to become available again
+  while curl -sI localhost:8080 >/dev/null; do
+    sleep 1
+  done
 done


### PR DESCRIPTION
When restart-on-change notices a config change and resets cTAKES, we've had reports of a race condition where the new cTAKES can't open a port because it's still claimed. This might be an OS-level delay or kill -9 is letting the process live for a bit.

Either way, this should wait for the old process to shut down.

## Testing
I've smoke tested that simple restart scenarios work. Race conditions are hard to confirm fixed though. Will have to gather reports once it's live.